### PR TITLE
Add type definition to EventSource constructor.

### DIFF
--- a/sse.d.ts
+++ b/sse.d.ts
@@ -9,7 +9,7 @@ declare module sse {
     enum ReadyState {CONNECTING = 0, OPEN = 1, CLOSED = 2}
     
     interface IEventSourceStatic extends EventTarget {
-        new (url: string, eventSourceInitDict?: IEventSourceInit);
+        new (url: string, eventSourceInitDict?: IEventSourceInit): IEventSourceStatic;
         url: string;
         withCredentials: boolean;
         CONNECTING: ReadyState; // constant, always 0


### PR DESCRIPTION
This change helps out users who compile their code with the --noImplicitAny flag.
